### PR TITLE
Modify glide.yaml to fix issue - Error scanning github.com/cpuguy83/g…

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -17,6 +17,8 @@ import:
   - leveldb/iterator
   - leveldb/opt
   - leveldb/util
+- package: github.com/urfave/cli
+  version: v1.22.0
 testImport:
 - package: github.com/stretchr/testify
   subpackages:


### PR DESCRIPTION
Looks like `github.com/urfave/cli` now at v1.22.2 is no longer compatible with glide.

When doing `glide update` I am getting the error

```
[ERROR]	Error scanning github.com/cpuguy83/go-md2man/v2/md2man: cannot find package "." in:
	/Users/clarencel/.glide/cache/src/https-github.com-cpuguy83-go-md2man/v2/md2man
[ERROR]	Failed to retrieve a list of dependencies: Error resolving imports
```

This keeps `urfave/cli` at version 1.22.0
